### PR TITLE
update libcoro to v0.14.1

### DIFF
--- a/cc-batteries/libcoro/default.nix
+++ b/cc-batteries/libcoro/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "libcoro";
-  version = "0.13.0";
+  version = "0.14.1";
 
 in stdenv.mkDerivation {
   inherit pname version;
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
     owner = "jbaldwin";
     repo = "libcoro";
     rev = "v${version}";
-    hash = "sha256-F891UYFX+0tzHHr4T4et7wI8cPp0If6ksb6iDgAvYCk=";
+    hash = "sha256-Tlul/1B1uIHJtN4JxP2uLaRnb4O1eBQ4QkCVdaRC/oM=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
升级libcoro, 主要是为了这个函数:
![image](https://github.com/user-attachments/assets/eba7c8c2-9892-4a95-b49f-c51b8bab8a90)
就是 `schedule` 可以带 timeout 了

---
然后当前repo我有一个疑问:
![image](https://github.com/user-attachments/assets/a3b5eb63-c903-4e62-85e6-a3bcabd5929e)
我不能通过直接`nix build`来检查对应tag的hash, 不得不手动改一下flake.nix的代码再`nix build`, 是有更帅的操作了吗?