### PR TITLE
Enable pyproject builds for dspy packages

### DIFF
--- a/gen-ai/dspy/default.nix
+++ b/gen-ai/dspy/default.nix
@@ -17,6 +17,7 @@ in buildPythonPackage {
     hash = "sha256-dccfZG3sv5fdZAQJOVIJB043GDdzWdk/pJxGuk0dYI4=";
   };
 
+  pyproject = true;
   build-system = [ setuptools ];
 
   dependencies = [

--- a/gen-ai/dspy/magicattr.nix
+++ b/gen-ai/dspy/magicattr.nix
@@ -14,6 +14,7 @@ in buildPythonPackage {
     hash = "sha256-FJtWU5AuunZbdlndGdfD1c9/0s7oRdoTi202pWjuAd8=";
   };
 
+  pyproject = true;
   build-system = [ setuptools ];
 
   meta = with lib; {


### PR DESCRIPTION
## Summary

- set `pyproject = true` in `gen-ai/dspy/default.nix` and `gen-ai/dspy/magicattr.nix`
- align both derivations with this repo's preferred modern Python packaging style

## Changes

### Packaging
- `gen-ai/dspy/default.nix:20` enables pyproject-based builds for `dspy`
- `gen-ai/dspy/magicattr.nix:17` enables pyproject-based builds for `magicattr`

## Test Plan

- [x] Build the `dspy` derivation and confirm the pyproject flow works
- [x] Build the `magicattr` derivation and confirm the pyproject flow works


🤖 Generated with [Claude Code](https://claude.com/claude-code)